### PR TITLE
feat: add missing assign import

### DIFF
--- a/playground/machines/loading.ts
+++ b/playground/machines/loading.ts
@@ -1,6 +1,7 @@
 export default createMachine({
   id: 'loading',
   initial: 'idle',
+  predictableActionArguments: true,
   states: {
     idle: {
       on: {

--- a/src/parts/autoImports.ts
+++ b/src/parts/autoImports.ts
@@ -43,7 +43,8 @@ export const setupAutoImports = (isMinimal: boolean) => {
 }
 
 const xStateImports = [
-  'createMachine'
+  'createMachine',
+  'assign'
 ]
 
 const xStateComposables = [

--- a/src/parts/autoImports.ts
+++ b/src/parts/autoImports.ts
@@ -4,8 +4,6 @@ import { defineUnimportPreset } from 'unimport'
 export const setupAutoImports = (isMinimal: boolean) => {
   const nuxt = useNuxt()
 
-  const isDev = nuxt.options.dev
-
   nuxt.hook('autoImports:sources', (presets) => {
     // If minimal options is enabled import required
     // things from @xstate/vue/lib/fsm or @xstate/fsm


### PR DESCRIPTION
### 🔗 Linked issue

No opened issue

### 📖 Updated documentation

Docs update not required

### 📚 Description

Added auto-import of the `assign` utility function used for actions in finite state machines